### PR TITLE
Added support to specify the network used by container

### DIFF
--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -25,6 +25,7 @@ class Container
     private Process $process;
     private WaitInterface $wait;
 
+    private ?string $network = null;
     private ?string $healthCheckCommand = null;
     private int $healthCheckIntervalInMS;
 
@@ -85,6 +86,13 @@ class Container
         return $this;
     }
 
+    public function withNetwork(string $network): self
+    {
+        $this->network = $network;
+
+        return $this;
+    }
+
     public function run(bool $wait = true): self
     {
         $this->id = uniqid('testcontainer', true);
@@ -109,6 +117,11 @@ class Container
             $params[] = $this->healthCheckCommand;
             $params[] = '--health-interval';
             $params[] = $this->healthCheckIntervalInMS . 'ms';
+        }
+
+        if ($this->network !== null) {
+            $params[] = '--network';
+            $params[] = $this->network;
         }
 
         $params[] = $this->image;
@@ -210,6 +223,10 @@ class Container
 
     public function getAddress(): string
     {
+        if ($this->network !== null && !empty($this->inspectedData[0]['NetworkSettings']['Networks'][$this->network]['IPAddress'])) {
+            return $this->inspectedData[0]['NetworkSettings']['Networks'][$this->network]['IPAddress'];
+        }
+
         return $this->inspectedData[0]['NetworkSettings']['IPAddress'];
     }
 }


### PR DESCRIPTION
I'm using ddev and need to have the testcontainer in the same network, so with this PR you can specify the docker network it should use.

Also useful in other cases where docker compose is used.

Basically like: https://github.com/testcontainers/testcontainers-java/blob/main/core/src/main/java/org/testcontainers/containers/Container.java#L283