### PR TITLE
Support for waiting on tcp port to open

### DIFF
--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -167,13 +167,7 @@ class Container
         $this->process = new Process($params);
         $this->process->mustRun();
 
-        $inspect = new Process(['docker', 'inspect', $this->id]);
-        $inspect->mustRun();
-
-        /** @var ContainerInspectSingleNetwork|ContainerInspectMultipleNetworks $inspectedData  */
-        $inspectedData = json_decode($inspect->getOutput(), true, 512, JSON_THROW_ON_ERROR);
-
-        $this->inspectedData = $inspectedData;
+        $this->inspectedData = $this->getContainerInspect($this->id);
 
         Registry::add($this);
 

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -56,6 +56,11 @@ class Container
         return new Container($image);
     }
 
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
     public function withEntryPoint(string $entryPoint): self
     {
         $this->entryPoint = $entryPoint;

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -7,9 +7,9 @@ namespace Testcontainer\Container;
 use Symfony\Component\Process\Process;
 use Testcontainer\Exception\ContainerNotReadyException;
 use Testcontainer\Registry;
+use Testcontainer\Trait\DockerContainerAwareTrait;
 use Testcontainer\Wait\WaitForNothing;
 use Testcontainer\Wait\WaitInterface;
-use UnexpectedValueException;
 
 /**
  * @phpstan-type ContainerInspectSingleNetwork array<int, array{'NetworkSettings': array{'IPAddress': string}}>
@@ -18,6 +18,8 @@ use UnexpectedValueException;
  */
 class Container
 {
+    use DockerContainerAwareTrait;
+
     private string $id;
 
     private ?string $entryPoint = null;
@@ -259,20 +261,10 @@ class Container
 
     public function getAddress(): string
     {
-        if (is_string($this->network)) {
-            $containerAddress = $this->inspectedData[0]['NetworkSettings']['Networks'][$this->network]['IPAddress'] ?? null;
-
-            if (is_string($containerAddress)) {
-                return $containerAddress;
-            }
-        }
-
-        $containerAddress = $this->inspectedData[0]['NetworkSettings']['IPAddress'] ?? null;
-
-        if (is_string($containerAddress)) {
-            return $containerAddress;
-        }
-
-        throw new UnexpectedValueException('Unable to find container IP address');
+        return $this->getContainerAddress(
+            containerId: $this->id,
+            networkName: $this->network,
+            inspectedData: $this->inspectedData
+        );
     }
 }

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -15,6 +15,7 @@ use Testcontainer\Wait\WaitInterface;
  * @phpstan-type ContainerInspectSingleNetwork array<int, array{'NetworkSettings': array{'IPAddress': string}}>
  * @phpstan-type ContainerInspectMultipleNetworks array<int, array{'NetworkSettings': array{'Networks': array<string, array{'IPAddress': string}>}}>
  * @phpstan-type ContainerInspect ContainerInspectSingleNetwork|ContainerInspectMultipleNetworks
+ * @phpstan-type DockerNetwork array{CreatedAt: string, Driver: string, ID: string, IPv6: string, Internal: string, Labels: string, Name: string, Scope: string}
  */
 class Container
 {
@@ -167,7 +168,7 @@ class Container
         $this->process = new Process($params);
         $this->process->mustRun();
 
-        $this->inspectedData = $this->getContainerInspect($this->id);
+        $this->inspectedData = self::dockerContainerInspect($this->id);
 
         Registry::add($this);
 
@@ -255,7 +256,7 @@ class Container
 
     public function getAddress(): string
     {
-        return $this->getContainerAddress(
+        return self::dockerContainerAddress(
             containerId: $this->id,
             networkName: $this->network,
             inspectedData: $this->inspectedData

--- a/src/Trait/DockerContainerAwareTrait.php
+++ b/src/Trait/DockerContainerAwareTrait.php
@@ -24,11 +24,7 @@ trait DockerContainerAwareTrait
     protected function getContainerAddress(string $containerId, ?string $networkName = null, ?array $inspectedData = null): string
     {
         if (! is_array($inspectedData)) {
-            $process = new Process(['docker', 'inspect', $containerId]);
-            $process->mustRun();
-
-            /** @var ContainerInspect $inspectedData */
-            $inspectedData = json_decode($process->getOutput(), true, 512, JSON_THROW_ON_ERROR);
+            $inspectedData = $this->getContainerInspect($containerId);
         }
 
         if (is_string($networkName)) {
@@ -46,5 +42,20 @@ trait DockerContainerAwareTrait
         }
 
         throw new UnexpectedValueException('Unable to find container IP address');
+    }
+
+    /**
+     * @param string $containerId
+     * @return ContainerInspect
+     *
+     * @throws JsonException
+     */
+    protected function getContainerInspect(string $containerId): array
+    {
+        $process = new Process(['docker', 'inspect', $containerId]);
+        $process->mustRun();
+
+        /** @var ContainerInspect */
+        return json_decode($process->getOutput(), true, 512, JSON_THROW_ON_ERROR);
     }
 }

--- a/src/Trait/DockerContainerAwareTrait.php
+++ b/src/Trait/DockerContainerAwareTrait.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testcontainer\Trait;
+
+use JsonException;
+use Symfony\Component\Process\Process;
+use UnexpectedValueException;
+
+/**
+ * @phpstan-import-type ContainerInspect from \Testcontainer\Container\Container
+ */
+trait DockerContainerAwareTrait
+{
+    /**
+     * @param string $containerId
+     * @param string|null $networkName
+     * @param ContainerInspect|null $inspectedData
+     * @return string
+     *
+     * @throws JsonException
+     */
+    protected function getContainerAddress(string $containerId, ?string $networkName = null, ?array $inspectedData = null): string
+    {
+        if (! is_array($inspectedData)) {
+            $process = new Process(['docker', 'inspect', $containerId]);
+            $process->mustRun();
+
+            /** @var ContainerInspect $inspectedData */
+            $inspectedData = json_decode($process->getOutput(), true, 512, JSON_THROW_ON_ERROR);
+        }
+
+        if (is_string($networkName)) {
+            $containerAddress = $inspectedData[0]['NetworkSettings']['Networks'][$networkName]['IPAddress'] ?? null;
+
+            if (is_string($containerAddress)) {
+                return $containerAddress;
+            }
+        }
+
+        $containerAddress = $inspectedData[0]['NetworkSettings']['IPAddress'] ?? null;
+
+        if (is_string($containerAddress)) {
+            return $containerAddress;
+        }
+
+        throw new UnexpectedValueException('Unable to find container IP address');
+    }
+}

--- a/src/Wait/WaitForHttp.php
+++ b/src/Wait/WaitForHttp.php
@@ -58,7 +58,7 @@ class WaitForHttp implements WaitInterface
 
     public function wait(string $id): void
     {
-        $containerAddress = $this->getContainerAddress(containerId: $id);
+        $containerAddress = self::dockerContainerAddress(containerId: $id);
 
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, sprintf('http://%s:%d%s', $containerAddress, $this->port, $this->path));

--- a/src/Wait/WaitForTcpPortOpen.php
+++ b/src/Wait/WaitForTcpPortOpen.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testcontainer\Wait;
+
+use JsonException;
+use RuntimeException;
+use Symfony\Component\Process\Process;
+use Testcontainer\Exception\ContainerNotReadyException;
+
+/**
+ * @phpstan-type ContainerInspect array<int, array{'NetworkSettings': array{'IPAddress': string}}>
+ */
+final class WaitForTcpPortOpen implements WaitInterface
+{
+    public function __construct(private readonly int $port)
+    {
+    }
+
+    public static function make(int $port): self
+    {
+        return new self($port);
+    }
+
+    /**
+     * @throws JsonException
+     */
+    public function wait(string $id): void
+    {
+        if (@fsockopen($this->findContainerAddress($id), $this->port) === false) {
+            throw new ContainerNotReadyException($id, new RuntimeException('Unable to connect to container TCP port'));
+        }
+    }
+
+    /**
+     * @throws JsonException
+     */
+    private function findContainerAddress(string $id): string
+    {
+        $process = new Process(['docker', 'inspect', $id]);
+        $process->mustRun();
+
+        /** @var ContainerInspect $data */
+        $data = json_decode($process->getOutput(), true, 512, JSON_THROW_ON_ERROR);
+
+        $containerAddress = $data[0]['NetworkSettings']['IPAddress'] ?? null;
+
+        if (! is_string($containerAddress)) {
+            throw new ContainerNotReadyException($id, new RuntimeException('Unable to find container IP address'));
+        }
+
+        return $containerAddress;
+    }
+}

--- a/src/Wait/WaitForTcpPortOpen.php
+++ b/src/Wait/WaitForTcpPortOpen.php
@@ -10,7 +10,7 @@ use Symfony\Component\Process\Process;
 use Testcontainer\Exception\ContainerNotReadyException;
 
 /**
- * @phpstan-type ContainerInspect array<int, array{'NetworkSettings': array{'IPAddress': string}}>
+ * @phpstan-import-type ContainerInspect from \Testcontainer\Container\Container
  */
 final class WaitForTcpPortOpen implements WaitInterface
 {

--- a/src/Wait/WaitForTcpPortOpen.php
+++ b/src/Wait/WaitForTcpPortOpen.php
@@ -13,13 +13,13 @@ final class WaitForTcpPortOpen implements WaitInterface
 {
     use DockerContainerAwareTrait;
 
-    public function __construct(private readonly int $port)
+    public function __construct(private readonly int $port, private readonly ?string $network = null)
     {
     }
 
-    public static function make(int $port): self
+    public static function make(int $port, ?string $network = null): self
     {
-        return new self($port);
+        return new self($port, $network);
     }
 
     /**
@@ -27,7 +27,7 @@ final class WaitForTcpPortOpen implements WaitInterface
      */
     public function wait(string $id): void
     {
-        if (@fsockopen($this->getContainerAddress($id), $this->port) === false) {
+        if (@fsockopen(self::dockerContainerAddress(containerId: $id, networkName: $this->network), $this->port) === false) {
             throw new ContainerNotReadyException($id, new RuntimeException('Unable to connect to container TCP port'));
         }
     }


### PR DESCRIPTION
## Changes:
- Introduced DockerContainerAwareTrait to aid code reuse with common Docker commands
- Introduced WaitForTcpPortOpen
- Resolved PHPStan issues

The PR turned bigger than expected because of some unresolved issues with phpstan with the current main branch. I took the opportunity and made the logic for determining the container address reusable as a trait. I did a few refactorings as well.